### PR TITLE
feat: add 6 new metric families from existing API data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,12 @@ client := technitium.NewClient(server.URL, "test-token", timeout)
 | `technitium_cache_entries` | Gauge | Current cache entries |
 | `technitium_clients_total` | Gauge | Unique clients seen |
 | `technitium_zones` | Gauge | Total zones |
+| `technitium_queries_by_record_type_total` | Counter | Queries by DNS record type (A, AAAA, TXT, etc.) |
+| `technitium_queries_by_protocol_total` | Counter | Queries by transport protocol (udp, tcp, etc.) |
+| `technitium_top_clients_hits` | Gauge | Top clients by query count (gated by `--collector.top-entries`) |
+| `technitium_top_domains_hits` | Gauge | Top queried domains by hit count (gated by `--collector.top-entries`) |
+| `technitium_top_blocked_domains_hits` | Gauge | Top blocked domains by hit count (gated by `--collector.top-entries`) |
+| `technitium_server_uptime_seconds` | Gauge | Server uptime in seconds (requires admin token) |
 
 ## Code Style
 

--- a/cmd/technitium_exporter/main.go
+++ b/cmd/technitium_exporter/main.go
@@ -39,6 +39,10 @@ func main() {
 		Default("info").
 		Enum("debug", "info", "warn", "error")
 
+	topEntries := app.Flag("collector.top-entries",
+		"Enable top clients/domains/blocked domains metrics.").
+		Default("true").Bool()
+
 	if _, err := app.Parse(os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "Error parsing command line: %v\n", err)
 		os.Exit(1)
@@ -83,7 +87,7 @@ func main() {
 	client := technitium.NewClient(cfg.TechnitiumURL, cfg.TechnitiumToken, cfg.ScrapeTimeout)
 
 	// Create and register collector.
-	coll := collector.NewCollector(client, logger)
+	coll := collector.NewCollector(client, logger, *topEntries)
 	prometheus.MustRegister(coll)
 
 	// Set up HTTP handlers.

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -20,92 +20,70 @@ type Collector struct {
 	logger *slog.Logger
 
 	// Metric descriptors.
-	up               *prometheus.Desc
-	scrapeDuration   *prometheus.Desc
-	serverInfo       *prometheus.Desc
-	queriesTotal     *prometheus.Desc
-	responsesTotal   *prometheus.Desc
-	queriesByType    *prometheus.Desc
-	blockedTotal     *prometheus.Desc
-	blocklistDomains *prometheus.Desc
-	blockedZones     *prometheus.Desc
-	allowedZones     *prometheus.Desc
-	cacheEntries     *prometheus.Desc
-	clients          *prometheus.Desc
-	zones            *prometheus.Desc
+	up                  *prometheus.Desc
+	scrapeDuration      *prometheus.Desc
+	serverInfo          *prometheus.Desc
+	queriesTotal        *prometheus.Desc
+	responsesTotal      *prometheus.Desc
+	queriesByType       *prometheus.Desc
+	blockedTotal        *prometheus.Desc
+	blocklistDomains    *prometheus.Desc
+	blockedZones        *prometheus.Desc
+	allowedZones        *prometheus.Desc
+	cacheEntries        *prometheus.Desc
+	clients             *prometheus.Desc
+	zones               *prometheus.Desc
+	queriesByRecordType *prometheus.Desc
+	queriesByProtocol   *prometheus.Desc
+	uptimeSeconds       *prometheus.Desc
+
+	// Optional top-entry descriptors (nil when disabled).
+	topClients        *prometheus.Desc
+	topDomains        *prometheus.Desc
+	topBlockedDomains *prometheus.Desc
+
+	topEntriesEnabled bool
+}
+
+// newDesc creates a prometheus.Desc with the namespace prefix.
+func newDesc(subsystem, name, help string, labels ...string) *prometheus.Desc {
+	return prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystem, name),
+		help, labels, nil,
+	)
 }
 
 // NewCollector creates a new Technitium collector.
-func NewCollector(client *technitium.Client, logger *slog.Logger) *Collector {
-	return &Collector{
-		client: client,
-		logger: logger,
-		up: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "up"),
-			"Whether the Technitium server is reachable.",
-			nil, nil,
-		),
-		scrapeDuration: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "scrape_duration_seconds"),
-			"Time taken to scrape metrics from Technitium.",
-			nil, nil,
-		),
-		serverInfo: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "server", "info"),
-			"Technitium DNS server information.",
-			[]string{"version", "server_domain"}, nil,
-		),
-		queriesTotal: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "queries", "total"),
-			"Total DNS queries processed.",
-			nil, nil,
-		),
-		responsesTotal: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "responses", "total"),
-			"DNS responses by response code.",
-			[]string{"rcode"}, nil,
-		),
-		queriesByType: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "queries_by_type", "total"),
-			"DNS queries by resolution type.",
-			[]string{"type"}, nil,
-		),
-		blockedTotal: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "blocked_queries", "total"),
-			"Total blocked DNS queries.",
-			nil, nil,
-		),
-		blocklistDomains: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "blocklist_domains"),
-			"Number of domains in blocklists.",
-			nil, nil,
-		),
-		blockedZones: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "blocked_zones"),
-			"Number of blocked zones configured.",
-			nil, nil,
-		),
-		allowedZones: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "allowed_zones"),
-			"Number of allowed zones configured.",
-			nil, nil,
-		),
-		cacheEntries: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "cache", "entries"),
-			"Current number of entries in cache.",
-			nil, nil,
-		),
-		clients: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "clients", "total"),
-			"Total unique clients seen.",
-			nil, nil,
-		),
-		zones: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "zones"),
-			"Total number of zones.",
-			nil, nil,
-		),
+func NewCollector(client *technitium.Client, logger *slog.Logger, topEntries bool) *Collector {
+	c := &Collector{
+		client:              client,
+		logger:              logger,
+		topEntriesEnabled:   topEntries,
+		up:                  newDesc("", "up", "Whether the Technitium server is reachable."),
+		scrapeDuration:      newDesc("", "scrape_duration_seconds", "Time taken to scrape metrics from Technitium."),
+		serverInfo:          newDesc("server", "info", "Technitium DNS server information.", "version", "server_domain"),
+		queriesTotal:        newDesc("queries", "total", "Total DNS queries processed."),
+		responsesTotal:      newDesc("responses", "total", "DNS responses by response code.", "rcode"),
+		queriesByType:       newDesc("queries_by_type", "total", "DNS queries by resolution type.", "type"),
+		blockedTotal:        newDesc("blocked_queries", "total", "Total blocked DNS queries."),
+		blocklistDomains:    newDesc("", "blocklist_domains", "Number of domains in blocklists."),
+		blockedZones:        newDesc("", "blocked_zones", "Number of blocked zones configured."),
+		allowedZones:        newDesc("", "allowed_zones", "Number of allowed zones configured."),
+		cacheEntries:        newDesc("cache", "entries", "Current number of entries in cache."),
+		clients:             newDesc("clients", "total", "Total unique clients seen."),
+		zones:               newDesc("", "zones", "Total number of zones."),
+		queriesByRecordType: newDesc("queries_by_record_type", "total", "DNS queries by record type (A, AAAA, TXT, etc.).", "record_type"),
+		queriesByProtocol:   newDesc("queries_by_protocol", "total", "DNS queries by transport protocol.", "protocol"),
+		uptimeSeconds:       newDesc("server", "uptime_seconds", "Technitium DNS server uptime in seconds."),
 	}
+
+	if topEntries {
+		c.topClients = newDesc("top_clients", "hits", "Top clients by query count.", "client", "rate_limited")
+		c.topDomains = newDesc("top_domains", "hits", "Top queried domains by hit count.", "domain")
+		c.topBlockedDomains = newDesc("top_blocked_domains", "hits", "Top blocked domains by hit count.", "domain")
+	}
+
+	return c
 }
 
 // Describe sends all metric descriptors to the provided channel.
@@ -123,6 +101,15 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.cacheEntries
 	ch <- c.clients
 	ch <- c.zones
+	ch <- c.queriesByRecordType
+	ch <- c.queriesByProtocol
+	ch <- c.uptimeSeconds
+
+	if c.topEntriesEnabled {
+		ch <- c.topClients
+		ch <- c.topDomains
+		ch <- c.topBlockedDomains
+	}
 }
 
 // Collect fetches metrics from Technitium and sends them to the provided channel.

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -4,6 +4,8 @@ package collector
 import (
 	"context"
 	"log/slog"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -191,4 +193,72 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.cacheEntries, prometheus.GaugeValue, float64(s.CachedEntries))
 	ch <- prometheus.MustNewConstMetric(c.clients, prometheus.GaugeValue, float64(s.TotalClients))
 	ch <- prometheus.MustNewConstMetric(c.zones, prometheus.GaugeValue, float64(s.Zones))
+
+	// Chart data and top entries.
+	c.collectChartData(ch, stats)
+
+	// Server uptime from settings endpoint.
+	if settingsErr == nil {
+		c.collectUptime(ch, settings)
+	}
+}
+
+// collectChartData emits metrics from the dashboard chart data and top-N lists.
+func (c *Collector) collectChartData(ch chan<- prometheus.Metric, stats *technitium.StatsResponse) {
+	// Query type chart data (A, AAAA, TXT, etc.).
+	for recordType, count := range stats.Response.QueryTypeChartData {
+		ch <- prometheus.MustNewConstMetric(
+			c.queriesByRecordType, prometheus.CounterValue,
+			float64(count), recordType,
+		)
+	}
+
+	// Protocol type chart data (UDP, TCP, etc.).
+	for protocol, count := range stats.Response.ProtocolTypeChartData {
+		ch <- prometheus.MustNewConstMetric(
+			c.queriesByProtocol, prometheus.CounterValue,
+			float64(count), strings.ToLower(protocol),
+		)
+	}
+
+	if !c.topEntriesEnabled {
+		return
+	}
+
+	// Top clients.
+	for _, client := range stats.Response.TopClients {
+		ch <- prometheus.MustNewConstMetric(
+			c.topClients, prometheus.GaugeValue,
+			float64(client.Hits), client.Name,
+			strconv.FormatBool(client.RateLimited),
+		)
+	}
+
+	// Top domains.
+	for _, domain := range stats.Response.TopDomains {
+		ch <- prometheus.MustNewConstMetric(
+			c.topDomains, prometheus.GaugeValue,
+			float64(domain.Hits), domain.Name,
+		)
+	}
+
+	// Top blocked domains.
+	for _, domain := range stats.Response.TopBlockedDomains {
+		ch <- prometheus.MustNewConstMetric(
+			c.topBlockedDomains, prometheus.GaugeValue,
+			float64(domain.Hits), domain.Name,
+		)
+	}
+}
+
+// collectUptime emits the server uptime metric from the settings endpoint.
+func (c *Collector) collectUptime(ch chan<- prometheus.Metric, settings *technitium.SettingsResponse) {
+	startTime, err := time.Parse(time.RFC3339, settings.Response.Uptimestamp)
+	if err != nil {
+		c.logger.Debug("Failed to parse uptimestamp", "err", err)
+		return
+	}
+
+	uptime := time.Since(startTime).Seconds()
+	ch <- prometheus.MustNewConstMetric(c.uptimeSeconds, prometheus.GaugeValue, uptime)
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -206,20 +206,13 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 // collectChartData emits metrics from the dashboard chart data and top-N lists.
 func (c *Collector) collectChartData(ch chan<- prometheus.Metric, stats *technitium.StatsResponse) {
 	// Query type chart data (A, AAAA, TXT, etc.).
-	for recordType, count := range stats.Response.QueryTypeChartData {
-		ch <- prometheus.MustNewConstMetric(
-			c.queriesByRecordType, prometheus.CounterValue,
-			float64(count), recordType,
-		)
-	}
+	// The API returns Chart.js format: labels[] and datasets[0].data[] are parallel arrays.
+	emitChartMetrics(ch, c.queriesByRecordType, prometheus.CounterValue,
+		stats.Response.QueryTypeChartData, false)
 
 	// Protocol type chart data (UDP, TCP, etc.).
-	for protocol, count := range stats.Response.ProtocolTypeChartData {
-		ch <- prometheus.MustNewConstMetric(
-			c.queriesByProtocol, prometheus.CounterValue,
-			float64(count), strings.ToLower(protocol),
-		)
-	}
+	emitChartMetrics(ch, c.queriesByProtocol, prometheus.CounterValue,
+		stats.Response.ProtocolTypeChartData, true)
 
 	if !c.topEntriesEnabled {
 		return
@@ -248,6 +241,29 @@ func (c *Collector) collectChartData(ch chan<- prometheus.Metric, stats *technit
 			c.topBlockedDomains, prometheus.GaugeValue,
 			float64(domain.Hits), domain.Name,
 		)
+	}
+}
+
+// emitChartMetrics emits metrics from Chart.js formatted data by zipping labels with data values.
+func emitChartMetrics(
+	ch chan<- prometheus.Metric,
+	desc *prometheus.Desc,
+	valueType prometheus.ValueType,
+	chart technitium.ChartData,
+	lowercaseLabel bool,
+) {
+	if len(chart.Datasets) == 0 {
+		return
+	}
+	data := chart.Datasets[0].Data
+	for i, label := range chart.Labels {
+		if i >= len(data) {
+			break
+		}
+		if lowercaseLabel {
+			label = strings.ToLower(label)
+		}
+		ch <- prometheus.MustNewConstMetric(desc, valueType, float64(data[i]), label)
 	}
 }
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -46,7 +46,20 @@ func realWorldStatsJSON() string {
 				"allowedZones": 0,
 				"blockedZones": 0,
 				"blockListZones": 214040
-			}
+			},
+			"queryTypeChartData": {"A": 40, "AAAA": 25, "PTR": 5, "TXT": 2},
+			"protocolTypeChartData": {"UDP": 65, "TCP": 7},
+			"topClients": [
+				{"name": "10.10.11.18", "hits": 50, "rateLimited": false},
+				{"name": "10.10.11.1", "hits": 22, "rateLimited": false}
+			],
+			"topDomains": [
+				{"name": "dns03.fartlab.dev", "hits": 30},
+				{"name": "example.com", "hits": 15}
+			],
+			"topBlockedDomains": [
+				{"name": "ads.example.com", "hits": 8}
+			]
 		}
 	}`
 }
@@ -74,7 +87,21 @@ func highTrafficStatsJSON() string {
 				"allowedZones": 5,
 				"blockedZones": 12,
 				"blockListZones": 500000
-			}
+			},
+			"queryTypeChartData": {"A": 800000, "AAAA": 500000, "TXT": 100000, "HTTPS": 50000, "PTR": 30000, "SRV": 2000},
+			"protocolTypeChartData": {"UDP": 1400000, "TCP": 123456},
+			"topClients": [
+				{"name": "10.0.0.1", "hits": 250000, "rateLimited": false},
+				{"name": "10.0.0.2", "hits": 180000, "rateLimited": true}
+			],
+			"topDomains": [
+				{"name": "api.github.com", "hits": 50000},
+				{"name": "dns.google", "hits": 30000}
+			],
+			"topBlockedDomains": [
+				{"name": "stats.grafana.org", "hits": 25000},
+				{"name": "telemetry.example.com", "hits": 15000}
+			]
 		}
 	}`
 }
@@ -131,10 +158,9 @@ func TestCollector_Collect_RealWorldData(t *testing.T) {
 		metricCount++
 	}
 
-	// We expect: up, scrapeDuration, serverInfo, queriesTotal, 4 responsesTotal, 5 queriesByType,
-	// blockedTotal, blocklistDomains, blockedZones, allowedZones, cacheEntries, clients, zones,
-	// uptimeSeconds = 21 metrics (no chart data in fixture yet).
-	expectedMetrics := 21
+	// We expect: 20 original + 4 queryTypeChartData + 2 protocolTypeChartData +
+	// 2 topClients + 2 topDomains + 1 topBlockedDomains + 1 uptimeSeconds = 32.
+	expectedMetrics := 32
 	if metricCount != expectedMetrics {
 		t.Errorf("expected %d metrics, got %d", expectedMetrics, metricCount)
 	}
@@ -420,6 +446,173 @@ func TestCollector_JSONParsing(t *testing.T) {
 	}
 }
 
+func TestCollector_QueriesByRecordType(t *testing.T) {
+	server := newTestServer(highTrafficStatsJSON(), realWorldSettingsJSON(), http.StatusOK)
+	defer server.Close()
+
+	client := technitium.NewClient(server.URL, "test-token", testTimeout)
+	coll := NewCollector(client, newTestLogger(), true)
+
+	expected := `
+		# HELP technitium_queries_by_record_type_total DNS queries by record type (A, AAAA, TXT, etc.).
+		# TYPE technitium_queries_by_record_type_total counter
+		technitium_queries_by_record_type_total{record_type="A"} 800000
+		technitium_queries_by_record_type_total{record_type="AAAA"} 500000
+		technitium_queries_by_record_type_total{record_type="HTTPS"} 50000
+		technitium_queries_by_record_type_total{record_type="PTR"} 30000
+		technitium_queries_by_record_type_total{record_type="SRV"} 2000
+		technitium_queries_by_record_type_total{record_type="TXT"} 100000
+	`
+	if err := testutil.CollectAndCompare(coll, strings.NewReader(expected), "technitium_queries_by_record_type_total"); err != nil {
+		t.Errorf("unexpected metrics for technitium_queries_by_record_type_total: %v", err)
+	}
+}
+
+func TestCollector_QueriesByProtocol(t *testing.T) {
+	server := newTestServer(highTrafficStatsJSON(), realWorldSettingsJSON(), http.StatusOK)
+	defer server.Close()
+
+	client := technitium.NewClient(server.URL, "test-token", testTimeout)
+	coll := NewCollector(client, newTestLogger(), true)
+
+	expected := `
+		# HELP technitium_queries_by_protocol_total DNS queries by transport protocol.
+		# TYPE technitium_queries_by_protocol_total counter
+		technitium_queries_by_protocol_total{protocol="tcp"} 123456
+		technitium_queries_by_protocol_total{protocol="udp"} 1.4e+06
+	`
+	if err := testutil.CollectAndCompare(coll, strings.NewReader(expected), "technitium_queries_by_protocol_total"); err != nil {
+		t.Errorf("unexpected metrics for technitium_queries_by_protocol_total: %v", err)
+	}
+}
+
+func TestCollector_TopClients(t *testing.T) {
+	server := newTestServer(highTrafficStatsJSON(), realWorldSettingsJSON(), http.StatusOK)
+	defer server.Close()
+
+	client := technitium.NewClient(server.URL, "test-token", testTimeout)
+	coll := NewCollector(client, newTestLogger(), true)
+
+	expected := `
+		# HELP technitium_top_clients_hits Top clients by query count.
+		# TYPE technitium_top_clients_hits gauge
+		technitium_top_clients_hits{client="10.0.0.1",rate_limited="false"} 250000
+		technitium_top_clients_hits{client="10.0.0.2",rate_limited="true"} 180000
+	`
+	if err := testutil.CollectAndCompare(coll, strings.NewReader(expected), "technitium_top_clients_hits"); err != nil {
+		t.Errorf("unexpected metrics for technitium_top_clients_hits: %v", err)
+	}
+}
+
+func TestCollector_TopDomains(t *testing.T) {
+	server := newTestServer(highTrafficStatsJSON(), realWorldSettingsJSON(), http.StatusOK)
+	defer server.Close()
+
+	client := technitium.NewClient(server.URL, "test-token", testTimeout)
+	coll := NewCollector(client, newTestLogger(), true)
+
+	expected := `
+		# HELP technitium_top_domains_hits Top queried domains by hit count.
+		# TYPE technitium_top_domains_hits gauge
+		technitium_top_domains_hits{domain="api.github.com"} 50000
+		technitium_top_domains_hits{domain="dns.google"} 30000
+	`
+	if err := testutil.CollectAndCompare(coll, strings.NewReader(expected), "technitium_top_domains_hits"); err != nil {
+		t.Errorf("unexpected metrics for technitium_top_domains_hits: %v", err)
+	}
+}
+
+func TestCollector_TopBlockedDomains(t *testing.T) {
+	server := newTestServer(highTrafficStatsJSON(), realWorldSettingsJSON(), http.StatusOK)
+	defer server.Close()
+
+	client := technitium.NewClient(server.URL, "test-token", testTimeout)
+	coll := NewCollector(client, newTestLogger(), true)
+
+	expected := `
+		# HELP technitium_top_blocked_domains_hits Top blocked domains by hit count.
+		# TYPE technitium_top_blocked_domains_hits gauge
+		technitium_top_blocked_domains_hits{domain="stats.grafana.org"} 25000
+		technitium_top_blocked_domains_hits{domain="telemetry.example.com"} 15000
+	`
+	if err := testutil.CollectAndCompare(coll, strings.NewReader(expected), "technitium_top_blocked_domains_hits"); err != nil {
+		t.Errorf("unexpected metrics for technitium_top_blocked_domains_hits: %v", err)
+	}
+}
+
+func TestCollector_TopEntriesDisabled(t *testing.T) {
+	server := newTestServer(highTrafficStatsJSON(), realWorldSettingsJSON(), http.StatusOK)
+	defer server.Close()
+
+	client := technitium.NewClient(server.URL, "test-token", testTimeout)
+	coll := NewCollector(client, newTestLogger(), false)
+
+	// Verify descriptor count is 16 (19 - 3 top-entry descriptors).
+	descCh := make(chan *prometheus.Desc, 100)
+	coll.Describe(descCh)
+	close(descCh)
+
+	descCount := 0
+	for range descCh {
+		descCount++
+	}
+	if descCount != 16 {
+		t.Errorf("expected 16 descriptors with top entries disabled, got %d", descCount)
+	}
+
+	// Verify top_clients, top_domains, top_blocked_domains are NOT emitted.
+	metricCount := testutil.CollectAndCount(coll, "technitium_top_clients_hits")
+	if metricCount != 0 {
+		t.Errorf("expected 0 top_clients metrics when disabled, got %d", metricCount)
+	}
+	metricCount = testutil.CollectAndCount(coll, "technitium_top_domains_hits")
+	if metricCount != 0 {
+		t.Errorf("expected 0 top_domains metrics when disabled, got %d", metricCount)
+	}
+	metricCount = testutil.CollectAndCount(coll, "technitium_top_blocked_domains_hits")
+	if metricCount != 0 {
+		t.Errorf("expected 0 top_blocked_domains metrics when disabled, got %d", metricCount)
+	}
+
+	// Verify record_type and protocol metrics ARE still emitted.
+	metricCount = testutil.CollectAndCount(coll, "technitium_queries_by_record_type_total")
+	if metricCount == 0 {
+		t.Error("expected queries_by_record_type metrics when top entries disabled, got 0")
+	}
+	metricCount = testutil.CollectAndCount(coll, "technitium_queries_by_protocol_total")
+	if metricCount == 0 {
+		t.Error("expected queries_by_protocol metrics when top entries disabled, got 0")
+	}
+}
+
+func TestCollector_UptimeSeconds(t *testing.T) {
+	server := newTestServer(realWorldStatsJSON(), realWorldSettingsJSON(), http.StatusOK)
+	defer server.Close()
+
+	client := technitium.NewClient(server.URL, "test-token", testTimeout)
+	coll := NewCollector(client, newTestLogger(), true)
+
+	// Uptime should be a positive value (settings has uptimestamp "2024-01-15T10:30:00Z").
+	metricCount := testutil.CollectAndCount(coll, "technitium_server_uptime_seconds")
+	if metricCount != 1 {
+		t.Errorf("expected 1 uptime metric, got %d", metricCount)
+	}
+}
+
+func TestCollector_UptimeSeconds_NoSettings(t *testing.T) {
+	server := newTestServer(realWorldStatsJSON(), errorResponseJSON(), http.StatusOK)
+	defer server.Close()
+
+	client := technitium.NewClient(server.URL, "test-token", testTimeout)
+	coll := NewCollector(client, newTestLogger(), true)
+
+	// Uptime should NOT be emitted when settings endpoint fails.
+	metricCount := testutil.CollectAndCount(coll, "technitium_server_uptime_seconds")
+	if metricCount != 0 {
+		t.Errorf("expected 0 uptime metrics when settings fail, got %d", metricCount)
+	}
+}
+
 // TestStatsResponse_Unmarshal verifies JSON unmarshaling works correctly.
 func TestStatsResponse_Unmarshal(t *testing.T) {
 	jsonData := realWorldStatsJSON()
@@ -439,5 +632,16 @@ func TestStatsResponse_Unmarshal(t *testing.T) {
 	}
 	if resp.Response.Stats.BlockListZones != 214040 {
 		t.Errorf("expected blockListZones 214040, got %d", resp.Response.Stats.BlockListZones)
+	}
+
+	// Verify chart data fields parse correctly.
+	if got := resp.Response.QueryTypeChartData["A"]; got != 40 {
+		t.Errorf("QueryTypeChartData[A] = %v, want 40", got)
+	}
+	if got := len(resp.Response.TopClients); got != 2 {
+		t.Errorf("len(TopClients) = %v, want 2", got)
+	}
+	if got := len(resp.Response.TopBlockedDomains); got != 1 {
+		t.Errorf("len(TopBlockedDomains) = %v, want 1", got)
 	}
 }

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -47,8 +47,14 @@ func realWorldStatsJSON() string {
 				"blockedZones": 0,
 				"blockListZones": 214040
 			},
-			"queryTypeChartData": {"A": 40, "AAAA": 25, "PTR": 5, "TXT": 2},
-			"protocolTypeChartData": {"UDP": 65, "TCP": 7},
+			"queryTypeChartData": {
+				"labels": ["A", "AAAA", "PTR", "TXT"],
+				"datasets": [{"data": [40, 25, 5, 2]}]
+			},
+			"protocolTypeChartData": {
+				"labels": ["Udp", "Tcp"],
+				"datasets": [{"data": [65, 7]}]
+			},
 			"topClients": [
 				{"name": "10.10.11.18", "hits": 50, "rateLimited": false},
 				{"name": "10.10.11.1", "hits": 22, "rateLimited": false}
@@ -88,8 +94,14 @@ func highTrafficStatsJSON() string {
 				"blockedZones": 12,
 				"blockListZones": 500000
 			},
-			"queryTypeChartData": {"A": 800000, "AAAA": 500000, "TXT": 100000, "HTTPS": 50000, "PTR": 30000, "SRV": 2000},
-			"protocolTypeChartData": {"UDP": 1400000, "TCP": 123456},
+			"queryTypeChartData": {
+				"labels": ["A", "AAAA", "TXT", "HTTPS", "PTR", "SRV"],
+				"datasets": [{"data": [800000, 500000, 100000, 50000, 30000, 2000]}]
+			},
+			"protocolTypeChartData": {
+				"labels": ["Udp", "Tcp"],
+				"datasets": [{"data": [1400000, 123456]}]
+			},
 			"topClients": [
 				{"name": "10.0.0.1", "hits": 250000, "rateLimited": false},
 				{"name": "10.0.0.2", "hits": 180000, "rateLimited": true}
@@ -635,8 +647,8 @@ func TestStatsResponse_Unmarshal(t *testing.T) {
 	}
 
 	// Verify chart data fields parse correctly.
-	if got := resp.Response.QueryTypeChartData["A"]; got != 40 {
-		t.Errorf("QueryTypeChartData[A] = %v, want 40", got)
+	if got := len(resp.Response.QueryTypeChartData.Labels); got != 4 {
+		t.Errorf("len(QueryTypeChartData.Labels) = %v, want 4", got)
 	}
 	if got := len(resp.Response.TopClients); got != 2 {
 		t.Errorf("len(TopClients) = %v, want 2", got)

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -132,8 +132,9 @@ func TestCollector_Collect_RealWorldData(t *testing.T) {
 	}
 
 	// We expect: up, scrapeDuration, serverInfo, queriesTotal, 4 responsesTotal, 5 queriesByType,
-	// blockedTotal, blocklistDomains, blockedZones, allowedZones, cacheEntries, clients, zones = 20 metrics.
-	expectedMetrics := 20
+	// blockedTotal, blocklistDomains, blockedZones, allowedZones, cacheEntries, clients, zones,
+	// uptimeSeconds = 21 metrics (no chart data in fixture yet).
+	expectedMetrics := 21
 	if metricCount != expectedMetrics {
 		t.Errorf("expected %d metrics, got %d", expectedMetrics, metricCount)
 	}

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -118,7 +118,7 @@ func TestCollector_Collect_RealWorldData(t *testing.T) {
 	defer server.Close()
 
 	client := technitium.NewClient(server.URL, "test-token", testTimeout)
-	coll := NewCollector(client, newTestLogger())
+	coll := NewCollector(client, newTestLogger(), true)
 
 	// Collect metrics.
 	ch := make(chan prometheus.Metric, 100)
@@ -144,7 +144,7 @@ func TestCollector_Collect_HighTrafficServer(t *testing.T) {
 	defer server.Close()
 
 	client := technitium.NewClient(server.URL, "test-token", testTimeout)
-	coll := NewCollector(client, newTestLogger())
+	coll := NewCollector(client, newTestLogger(), true)
 
 	// Test specific metric values using testutil.
 	expected := `
@@ -162,7 +162,7 @@ func TestCollector_Collect_SettingsAccessDenied(t *testing.T) {
 	defer server.Close()
 
 	client := technitium.NewClient(server.URL, "test-token", testTimeout)
-	coll := NewCollector(client, newTestLogger())
+	coll := NewCollector(client, newTestLogger(), true)
 
 	// Should still work with version="unknown".
 	expected := `
@@ -190,7 +190,7 @@ func TestCollector_Collect_StatsError(t *testing.T) {
 	defer server.Close()
 
 	client := technitium.NewClient(server.URL, "test-token", testTimeout)
-	coll := NewCollector(client, newTestLogger())
+	coll := NewCollector(client, newTestLogger(), true)
 
 	ch := make(chan prometheus.Metric, 100)
 	coll.Collect(ch)
@@ -212,7 +212,7 @@ func TestCollector_Collect_StatsHTTPError(t *testing.T) {
 	defer server.Close()
 
 	client := technitium.NewClient(server.URL, "test-token", testTimeout)
-	coll := NewCollector(client, newTestLogger())
+	coll := NewCollector(client, newTestLogger(), true)
 
 	expected := `
 		# HELP technitium_up Whether the Technitium server is reachable.
@@ -229,7 +229,7 @@ func TestCollector_Collect_BothEndpointsFail(t *testing.T) {
 	defer server.Close()
 
 	client := technitium.NewClient(server.URL, "test-token", testTimeout)
-	coll := NewCollector(client, newTestLogger())
+	coll := NewCollector(client, newTestLogger(), true)
 
 	expected := `
 		# HELP technitium_up Whether the Technitium server is reachable.
@@ -244,7 +244,7 @@ func TestCollector_Collect_BothEndpointsFail(t *testing.T) {
 func TestCollector_Collect_ServerUnreachable(t *testing.T) {
 	// Use a URL that will fail to connect.
 	client := technitium.NewClient("http://127.0.0.1:1", "test-token", testTimeout)
-	coll := NewCollector(client, newTestLogger())
+	coll := NewCollector(client, newTestLogger(), true)
 
 	expected := `
 		# HELP technitium_up Whether the Technitium server is reachable.
@@ -258,7 +258,7 @@ func TestCollector_Collect_ServerUnreachable(t *testing.T) {
 
 func TestCollector_Describe(t *testing.T) {
 	client := technitium.NewClient("http://localhost", "test-token", testTimeout)
-	coll := NewCollector(client, newTestLogger())
+	coll := NewCollector(client, newTestLogger(), true)
 
 	ch := make(chan *prometheus.Desc, 100)
 	coll.Describe(ch)
@@ -269,8 +269,8 @@ func TestCollector_Describe(t *testing.T) {
 		descCount++
 	}
 
-	// We expect 13 metric descriptors.
-	expectedDescs := 13
+	// We expect 19 metric descriptors (13 original + 3 chart data + 3 top entries).
+	expectedDescs := 19
 	if descCount != expectedDescs {
 		t.Errorf("expected %d descriptors, got %d", expectedDescs, descCount)
 	}
@@ -281,7 +281,7 @@ func TestCollector_MetricValues_RealWorld(t *testing.T) {
 	defer server.Close()
 
 	client := technitium.NewClient(server.URL, "test-token", testTimeout)
-	coll := NewCollector(client, newTestLogger())
+	coll := NewCollector(client, newTestLogger(), true)
 
 	// Test queries total.
 	expected := `
@@ -329,7 +329,7 @@ func TestCollector_ResponseCodes(t *testing.T) {
 	defer server.Close()
 
 	client := technitium.NewClient(server.URL, "test-token", testTimeout)
-	coll := NewCollector(client, newTestLogger())
+	coll := NewCollector(client, newTestLogger(), true)
 
 	expected := `
 		# HELP technitium_responses_total DNS responses by response code.
@@ -349,7 +349,7 @@ func TestCollector_QueryTypes(t *testing.T) {
 	defer server.Close()
 
 	client := technitium.NewClient(server.URL, "test-token", testTimeout)
-	coll := NewCollector(client, newTestLogger())
+	coll := NewCollector(client, newTestLogger(), true)
 
 	expected := `
 		# HELP technitium_queries_by_type_total DNS queries by resolution type.
@@ -397,7 +397,7 @@ func TestCollector_JSONParsing(t *testing.T) {
 	defer server.Close()
 
 	client := technitium.NewClient(server.URL, "test-token", testTimeout)
-	coll := NewCollector(client, newTestLogger())
+	coll := NewCollector(client, newTestLogger(), true)
 
 	// Verify specific parsed values.
 	expected := `

--- a/docs/exporter-enhancements-implementation.md
+++ b/docs/exporter-enhancements-implementation.md
@@ -372,7 +372,7 @@ make security
 - [x] `make test-coverage` -- all tests pass (collector: 97.8%, client: 91.5%)
 - [x] `make build` -- binary builds successfully
 - [x] `make security` -- no vulnerabilities (govulncheck clean, trivy 0 findings)
-- [ ] Manual smoke test: run the built binary against a test server (if
+- [x] Manual smoke test: run the built binary against a test server (if
   available) and curl `/metrics` to verify new metrics appear
 
 ---

--- a/docs/exporter-enhancements-implementation.md
+++ b/docs/exporter-enhancements-implementation.md
@@ -1,0 +1,435 @@
+# Exporter Enhancements: Implementation Plan
+
+Reference: [docs/exporter-enhancements-plan.md](exporter-enhancements-plan.md)
+
+## Overview
+
+This plan implements 6 new metric families from the existing
+`/api/dashboard/stats/get` response, adds a `--collector.top-entries` flag, and
+exposes server uptime from the settings endpoint. No new API calls are needed.
+
+**New metrics:**
+
+| Metric | Type | Source |
+|--------|------|--------|
+| `technitium_queries_by_record_type_total` | Counter | `queryTypeChartData` |
+| `technitium_queries_by_protocol_total` | Counter | `protocolTypeChartData` |
+| `technitium_top_clients_hits` | Gauge | `topClients` |
+| `technitium_top_domains_hits` | Gauge | `topDomains` |
+| `technitium_top_blocked_domains_hits` | Gauge | `topBlockedDomains` |
+| `technitium_server_uptime_seconds` | Gauge | `settings.uptimestamp` |
+
+---
+
+## Phase 1: Types
+
+**Goal:** Expand `StatsResponseData` to capture the unparsed API fields and add
+new types for top-N entries.
+
+**Files:** `pkg/technitium/types.go`
+
+**Changes:**
+
+1. Add fields to `StatsResponseData` (line 12):
+   - `QueryTypeChartData map[string]int64 json:"queryTypeChartData"`
+   - `ProtocolTypeChartData map[string]int64 json:"protocolTypeChartData"`
+   - `TopClients []TopClient json:"topClients"`
+   - `TopDomains []TopEntry json:"topDomains"`
+   - `TopBlockedDomains []TopEntry json:"topBlockedDomains"`
+
+2. Add `TopClient` struct:
+   - `Name string json:"name"`
+   - `Hits int64 json:"hits"`
+   - `RateLimited bool json:"rateLimited"`
+
+3. Add `TopEntry` struct:
+   - `Name string json:"name"`
+   - `Hits int64 json:"hits"`
+
+**Design notes:**
+- `map[string]int64` for chart data because keys are dynamic (API may return new
+  record types or protocols without code changes)
+- `TopClient` is separate from `TopEntry` because of the `rateLimited` field
+- `TopEntry` is reused for both `topDomains` and `topBlockedDomains`
+
+**Success criteria:**
+- [x] `go build ./...` compiles
+- [x] `go vet ./...` passes
+- [x] Existing tests still pass: `go test ./pkg/technitium/...`
+
+---
+
+## Phase 2: Client-level parsing tests
+
+**Goal:** Verify that `json.Unmarshal` correctly populates the new
+`StatsResponseData` fields from a realistic API response.
+
+**Files:** `pkg/technitium/client_test.go`
+
+**Changes:**
+
+1. Add `TestStatsResponse_ChartData` test:
+   - JSON fixture includes `queryTypeChartData`, `protocolTypeChartData`,
+     `topClients`, `topDomains`, `topBlockedDomains` alongside existing `stats`
+   - Assert `QueryTypeChartData["A"]` == expected value
+   - Assert `ProtocolTypeChartData["UDP"]` == expected value
+   - Assert `len(TopClients)` and first entry's `Name`, `Hits`, `RateLimited`
+   - Assert `len(TopDomains)` and first entry's `Name`, `Hits`
+   - Assert `len(TopBlockedDomains)` and first entry's `Name`, `Hits`
+
+2. Add `TestStatsResponse_EmptyChartData` test:
+   - JSON fixture with `stats` only (no chart data fields) -- verifies
+     backward compatibility (maps should be nil, slices should be nil)
+
+**Success criteria:**
+- [ ] `go test -v -run TestStatsResponse_ChartData ./pkg/technitium/...` passes
+- [ ] `go test -v -run TestStatsResponse_EmptyChartData ./pkg/technitium/...` passes
+- [ ] All existing client tests still pass
+
+---
+
+## Phase 3: Collector -- descriptors and constructor
+
+**Goal:** Add 6 new metric descriptors and the `topEntriesEnabled` flag to the
+collector. Update `NewCollector` signature to accept `topEntries bool`.
+
+**Files:** `collector/collector.go`, `cmd/technitium_exporter/main.go`
+
+**Changes to `collector/collector.go`:**
+
+1. Add imports: `"strconv"`, `"strings"`, `"time"` (as needed)
+
+2. Add 6 new fields to `Collector` struct (after line 35):
+   - `queriesByRecordType *prometheus.Desc`
+   - `queriesByProtocol *prometheus.Desc`
+   - `topClients *prometheus.Desc`
+   - `topDomains *prometheus.Desc`
+   - `topBlockedDomains *prometheus.Desc`
+   - `uptimeSeconds *prometheus.Desc`
+   - `topEntriesEnabled bool`
+
+3. Update `NewCollector` signature (line 39):
+   - From: `func NewCollector(client *technitium.Client, logger *slog.Logger) *Collector`
+   - To: `func NewCollector(client *technitium.Client, logger *slog.Logger, topEntries bool) *Collector`
+
+4. Add descriptor initializations in `NewCollector`:
+   - `queriesByRecordType`: always initialized
+     - FQName: `technitium_queries_by_record_type_total`
+     - Labels: `["record_type"]`
+   - `queriesByProtocol`: always initialized
+     - FQName: `technitium_queries_by_protocol_total`
+     - Labels: `["protocol"]`
+   - `uptimeSeconds`: always initialized
+     - FQName: `technitium_server_uptime_seconds`
+     - Labels: none
+   - `topClients`: only if `topEntries == true`
+     - FQName: `technitium_top_clients_hits`
+     - Labels: `["client", "rate_limited"]`
+   - `topDomains`: only if `topEntries == true`
+     - FQName: `technitium_top_domains_hits`
+     - Labels: `["domain"]`
+   - `topBlockedDomains`: only if `topEntries == true`
+     - FQName: `technitium_top_blocked_domains_hits`
+     - Labels: `["domain"]`
+
+5. Update `Describe()` (line 112):
+   - Add `ch <- c.queriesByRecordType`
+   - Add `ch <- c.queriesByProtocol`
+   - Add `ch <- c.uptimeSeconds`
+   - Guarded: `if c.topEntriesEnabled { ch <- c.topClients; ch <- c.topDomains; ch <- c.topBlockedDomains }`
+
+**Changes to `cmd/technitium_exporter/main.go`:**
+
+1. Add `--collector.top-entries` flag (after line 40, in the flag definition area):
+   ```
+   topEntries := app.Flag("collector.top-entries",
+       "Enable top clients/domains/blocked domains metrics.").
+       Default("true").Bool()
+   ```
+
+2. Update collector construction (line 86):
+   - From: `collector.NewCollector(client, logger)`
+   - To: `collector.NewCollector(client, logger, *topEntries)`
+
+**Success criteria:**
+- [ ] `go build ./...` compiles
+- [ ] `go vet ./...` passes
+- [ ] Existing tests compile (will need NewCollector call sites updated -- see
+  note below)
+
+**Note:** All existing test call sites of `NewCollector(client, logger)` will
+break because the signature changes. These must be updated to
+`NewCollector(client, logger, true)` in this phase to keep tests compiling. This
+is a mechanical find-and-replace in `collector/collector_test.go`.
+
+---
+
+## Phase 4: Collector -- collection logic
+
+**Goal:** Add the metric emission logic in `Collect()` for all 6 new metrics.
+
+**Files:** `collector/collector.go`
+
+**Changes to `Collect()` (after line 206):**
+
+1. **Query type chart data** -- iterate `stats.Response.QueryTypeChartData`:
+   ```go
+   for recordType, count := range stats.Response.QueryTypeChartData {
+       ch <- prometheus.MustNewConstMetric(
+           c.queriesByRecordType, prometheus.CounterValue,
+           float64(count), recordType,
+       )
+   }
+   ```
+
+2. **Protocol type chart data** -- iterate `stats.Response.ProtocolTypeChartData`:
+   ```go
+   for protocol, count := range stats.Response.ProtocolTypeChartData {
+       ch <- prometheus.MustNewConstMetric(
+           c.queriesByProtocol, prometheus.CounterValue,
+           float64(count), strings.ToLower(protocol),
+       )
+   }
+   ```
+
+3. **Top entries** -- guarded by `c.topEntriesEnabled`:
+   ```go
+   if c.topEntriesEnabled {
+       for _, client := range stats.Response.TopClients {
+           ch <- prometheus.MustNewConstMetric(
+               c.topClients, prometheus.GaugeValue,
+               float64(client.Hits), client.Name,
+               strconv.FormatBool(client.RateLimited),
+           )
+       }
+       for _, domain := range stats.Response.TopDomains {
+           ch <- prometheus.MustNewConstMetric(
+               c.topDomains, prometheus.GaugeValue,
+               float64(domain.Hits), domain.Name,
+           )
+       }
+       for _, domain := range stats.Response.TopBlockedDomains {
+           ch <- prometheus.MustNewConstMetric(
+               c.topBlockedDomains, prometheus.GaugeValue,
+               float64(domain.Hits), domain.Name,
+           )
+       }
+   }
+   ```
+
+4. **Uptime** -- after the existing settings handling block (around line 177):
+   ```go
+   if settingsErr == nil {
+       startTime, err := time.Parse(time.RFC3339, settings.Response.Uptimestamp)
+       if err == nil {
+           uptime := time.Since(startTime).Seconds()
+           ch <- prometheus.MustNewConstMetric(
+               c.uptimeSeconds, prometheus.GaugeValue, uptime,
+           )
+       }
+   }
+   ```
+
+**Success criteria:**
+- [ ] `go build ./...` compiles
+- [ ] `go vet ./...` passes
+- [ ] `make lint` passes (no new golangci-lint issues)
+- [ ] Existing tests still pass (no new data in fixtures yet, so new loops are
+  no-ops on nil maps/slices)
+
+---
+
+## Phase 5: Collector tests
+
+**Goal:** Update all test fixtures with chart data fields and add new test cases
+verifying the 6 new metrics.
+
+**Files:** `collector/collector_test.go`
+
+**Changes:**
+
+1. **Update `realWorldStatsJSON()`** -- add chart data fields to the `response`
+   object (after the `stats` block):
+   ```json
+   "queryTypeChartData": {"A": 40, "AAAA": 25, "PTR": 5, "TXT": 2},
+   "protocolTypeChartData": {"UDP": 65, "TCP": 7},
+   "topClients": [
+     {"name": "10.10.11.18", "hits": 50, "rateLimited": false},
+     {"name": "10.10.11.1", "hits": 22, "rateLimited": false}
+   ],
+   "topDomains": [
+     {"name": "dns03.fartlab.dev", "hits": 30},
+     {"name": "example.com", "hits": 15}
+   ],
+   "topBlockedDomains": [
+     {"name": "ads.example.com", "hits": 8}
+   ]
+   ```
+
+2. **Update `highTrafficStatsJSON()`** -- add chart data fields with larger
+   numbers:
+   ```json
+   "queryTypeChartData": {"A": 800000, "AAAA": 500000, "TXT": 100000, "HTTPS": 50000, "PTR": 30000, "SRV": 2000},
+   "protocolTypeChartData": {"UDP": 1400000, "TCP": 123456},
+   "topClients": [
+     {"name": "10.0.0.1", "hits": 250000, "rateLimited": false},
+     {"name": "10.0.0.2", "hits": 180000, "rateLimited": true}
+   ],
+   "topDomains": [
+     {"name": "api.github.com", "hits": 50000},
+     {"name": "dns.google", "hits": 30000}
+   ],
+   "topBlockedDomains": [
+     {"name": "stats.grafana.org", "hits": 25000},
+     {"name": "telemetry.example.com", "hits": 15000}
+   ]
+   ```
+
+3. **Update `NewCollector` call sites** (already done in Phase 3 note, but
+   verify): all `NewCollector(client, newTestLogger())` become
+   `NewCollector(client, newTestLogger(), true)`.
+
+4. **Update metric count in `TestCollector_Collect_RealWorldData`** (line 136):
+   - Old: 20 metrics
+   - New: 20 (existing) + 4 (queryTypeChartData: A, AAAA, PTR, TXT) + 2
+     (protocolTypeChartData: UDP, TCP) + 2 (topClients) + 2 (topDomains) + 1
+     (topBlockedDomains) + 1 (uptimeSeconds) = 32 metrics
+
+5. **Update descriptor count in `TestCollector_Describe`** (line 273):
+   - Old: 13 descriptors
+   - New: 13 + 6 (queriesByRecordType, queriesByProtocol, topClients,
+     topDomains, topBlockedDomains, uptimeSeconds) = 19 descriptors
+
+6. **Add `TestCollector_QueriesByRecordType`** -- verify record type metrics
+   using `testutil.CollectAndCompare` against `highTrafficStatsJSON()`:
+   ```
+   technitium_queries_by_record_type_total{record_type="A"} 800000
+   technitium_queries_by_record_type_total{record_type="AAAA"} 500000
+   ...
+   ```
+
+7. **Add `TestCollector_QueriesByProtocol`** -- verify protocol metrics:
+   ```
+   technitium_queries_by_protocol_total{protocol="udp"} 1400000
+   technitium_queries_by_protocol_total{protocol="tcp"} 123456
+   ```
+   (Note: label values are lowercased)
+
+8. **Add `TestCollector_TopClients`** -- verify top clients metrics:
+   ```
+   technitium_top_clients_hits{client="10.0.0.1",rate_limited="false"} 250000
+   technitium_top_clients_hits{client="10.0.0.2",rate_limited="true"} 180000
+   ```
+
+9. **Add `TestCollector_TopDomains`** -- verify top domains metrics.
+
+10. **Add `TestCollector_TopBlockedDomains`** -- verify top blocked domains
+    metrics.
+
+11. **Add `TestCollector_TopEntriesDisabled`** -- create collector with
+    `NewCollector(client, logger, false)`:
+    - Verify descriptor count is 16 (19 - 3 top-entry descriptors)
+    - Verify top_clients, top_domains, top_blocked_domains metrics are NOT
+      emitted
+    - Verify record_type, protocol, and uptime metrics ARE still emitted
+
+12. **Add `TestCollector_UptimeSeconds`** -- verify uptime metric is emitted
+    when settings succeed:
+    - Use `realWorldSettingsJSON()` which has
+      `"uptimestamp": "2024-01-15T10:30:00Z"`
+    - Verify `technitium_server_uptime_seconds` is a positive value (exact value
+      depends on wall clock, so just check it exists and is > 0)
+
+13. **Update `TestStatsResponse_Unmarshal`** (line 422):
+    - Update `realWorldStatsJSON()` already has new fields from step 1
+    - Add assertions for `resp.Response.QueryTypeChartData["A"]`,
+      `len(resp.Response.TopClients)`, etc.
+
+**Success criteria:**
+- [ ] `go test -v -race ./collector/...` -- all tests pass
+- [ ] `go test -v -race ./pkg/technitium/...` -- all tests pass
+- [ ] `make test` -- full test suite green
+- [ ] `make lint` -- no lint issues
+
+---
+
+## Phase 6: Full verification
+
+**Goal:** Run the complete CI-equivalent check locally.
+
+**Commands:**
+```bash
+make fmt
+make lint
+make test-coverage
+make build
+make security
+```
+
+**Success criteria:**
+- [ ] `make fmt` -- no formatting changes
+- [ ] `make lint` -- clean
+- [ ] `make test-coverage` -- all tests pass with coverage report
+- [ ] `make build` -- binary builds for all platforms
+- [ ] `make security` -- no HIGH/CRITICAL vulnerabilities
+- [ ] Manual smoke test: run the built binary against a test server (if
+  available) and curl `/metrics` to verify new metrics appear
+
+---
+
+## Phase 7: Documentation and dashboard (deferred)
+
+**Goal:** Update CLAUDE.md metrics table and Grafana dashboard with new panels.
+
+**Note:** This phase is deferred to a follow-up PR to keep the code changes
+focused and reviewable. The dashboard JSON changes are large and independent of
+the collector logic.
+
+**Files (when ready):**
+- `CLAUDE.md` -- add 6 new metrics to the table
+- `contrib/grafana/technitium-dashboard.json` -- add panels:
+  - Query Types piechart (donut)
+  - Protocol Distribution stat panel
+  - Top Clients table
+  - Top Domains table
+  - Top Blocked Domains table
+  - Server Uptime stat panel
+
+**Success criteria:**
+- [ ] CLAUDE.md metrics table matches actual output
+- [ ] Dashboard imports without errors in Grafana
+- [ ] All new panels render with data
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (types)
+    |
+    v
+Phase 2 (client parsing tests)
+    |
+    v
+Phase 3 (collector descriptors + constructor + main.go flag)
+    |
+    v
+Phase 4 (collector collection logic)
+    |
+    v
+Phase 5 (collector tests)
+    |
+    v
+Phase 6 (full verification)
+    |
+    v
+Phase 7 (docs + dashboard -- separate PR)
+```
+
+Each phase builds on the previous. Phases 1-6 are one PR. Phase 7 is a
+follow-up.
+
+## Open Questions
+
+None -- all decisions were resolved in the
+[enhancements plan](exporter-enhancements-plan.md#decisions).

--- a/docs/exporter-enhancements-implementation.md
+++ b/docs/exporter-enhancements-implementation.md
@@ -367,11 +367,11 @@ make security
 ```
 
 **Success criteria:**
-- [ ] `make fmt` -- no formatting changes
-- [ ] `make lint` -- clean
-- [ ] `make test-coverage` -- all tests pass with coverage report
-- [ ] `make build` -- binary builds for all platforms
-- [ ] `make security` -- no HIGH/CRITICAL vulnerabilities
+- [x] `make fmt` -- no formatting changes
+- [x] `make lint` -- clean (0 issues)
+- [x] `make test-coverage` -- all tests pass (collector: 97.8%, client: 91.5%)
+- [x] `make build` -- binary builds successfully
+- [x] `make security` -- no vulnerabilities (govulncheck clean, trivy 0 findings)
 - [ ] Manual smoke test: run the built binary against a test server (if
   available) and curl `/metrics` to verify new metrics appear
 

--- a/docs/exporter-enhancements-implementation.md
+++ b/docs/exporter-enhancements-implementation.md
@@ -82,9 +82,9 @@ new types for top-N entries.
      backward compatibility (maps should be nil, slices should be nil)
 
 **Success criteria:**
-- [ ] `go test -v -run TestStatsResponse_ChartData ./pkg/technitium/...` passes
-- [ ] `go test -v -run TestStatsResponse_EmptyChartData ./pkg/technitium/...` passes
-- [ ] All existing client tests still pass
+- [x] `go test -v -run TestStatsResponse_ChartData ./pkg/technitium/...` passes
+- [x] `go test -v -run TestStatsResponse_EmptyChartData ./pkg/technitium/...` passes
+- [x] All existing client tests still pass
 
 ---
 

--- a/docs/exporter-enhancements-implementation.md
+++ b/docs/exporter-enhancements-implementation.md
@@ -231,10 +231,10 @@ is a mechanical find-and-replace in `collector/collector_test.go`.
    ```
 
 **Success criteria:**
-- [ ] `go build ./...` compiles
-- [ ] `go vet ./...` passes
-- [ ] `make lint` passes (no new golangci-lint issues)
-- [ ] Existing tests still pass (no new data in fixtures yet, so new loops are
+- [x] `go build ./...` compiles
+- [x] `go vet ./...` passes
+- [x] `make lint` passes (no new golangci-lint issues)
+- [x] Existing tests still pass (no new data in fixtures yet, so new loops are
   no-ops on nil maps/slices)
 
 ---

--- a/docs/exporter-enhancements-implementation.md
+++ b/docs/exporter-enhancements-implementation.md
@@ -346,10 +346,10 @@ verifying the 6 new metrics.
       `len(resp.Response.TopClients)`, etc.
 
 **Success criteria:**
-- [ ] `go test -v -race ./collector/...` -- all tests pass
-- [ ] `go test -v -race ./pkg/technitium/...` -- all tests pass
-- [ ] `make test` -- full test suite green
-- [ ] `make lint` -- no lint issues
+- [x] `go test -v -race ./collector/...` -- all tests pass
+- [x] `go test -v -race ./pkg/technitium/...` -- all tests pass
+- [x] `make test` -- full test suite green
+- [x] `make lint` -- no lint issues
 
 ---
 

--- a/docs/exporter-enhancements-implementation.md
+++ b/docs/exporter-enhancements-implementation.md
@@ -152,9 +152,9 @@ collector. Update `NewCollector` signature to accept `topEntries bool`.
    - To: `collector.NewCollector(client, logger, *topEntries)`
 
 **Success criteria:**
-- [ ] `go build ./...` compiles
-- [ ] `go vet ./...` passes
-- [ ] Existing tests compile (will need NewCollector call sites updated -- see
+- [x] `go build ./...` compiles
+- [x] `go vet ./...` passes
+- [x] Existing tests compile (will need NewCollector call sites updated -- see
   note below)
 
 **Note:** All existing test call sites of `NewCollector(client, logger)` will

--- a/pkg/technitium/client_test.go
+++ b/pkg/technitium/client_test.go
@@ -236,8 +236,14 @@ func TestStatsResponse_ChartData(t *testing.T) {
 				"blockedZones": 1,
 				"blockListZones": 50000
 			},
-			"queryTypeChartData": {"A": 100, "AAAA": 40, "TXT": 10, "HTTPS": 5, "PTR": 5},
-			"protocolTypeChartData": {"UDP": 140, "TCP": 20},
+			"queryTypeChartData": {
+				"labels": ["A", "AAAA", "TXT", "HTTPS", "PTR"],
+				"datasets": [{"data": [100, 40, 10, 5, 5]}]
+			},
+			"protocolTypeChartData": {
+				"labels": ["Udp", "Tcp"],
+				"datasets": [{"data": [140, 20]}]
+			},
 			"topClients": [
 				{"name": "10.0.0.1", "hits": 80, "rateLimited": false},
 				{"name": "10.0.0.2", "hits": 60, "rateLimited": true}
@@ -257,23 +263,23 @@ func TestStatsResponse_ChartData(t *testing.T) {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}
 
-	// Verify queryTypeChartData.
-	if got := resp.Response.QueryTypeChartData["A"]; got != 100 {
-		t.Errorf("QueryTypeChartData[A] = %v, want 100", got)
+	// Verify queryTypeChartData (Chart.js format).
+	if got := len(resp.Response.QueryTypeChartData.Labels); got != 5 {
+		t.Errorf("len(QueryTypeChartData.Labels) = %v, want 5", got)
 	}
-	if got := resp.Response.QueryTypeChartData["AAAA"]; got != 40 {
-		t.Errorf("QueryTypeChartData[AAAA] = %v, want 40", got)
+	if got := resp.Response.QueryTypeChartData.Labels[0]; got != "A" {
+		t.Errorf("QueryTypeChartData.Labels[0] = %v, want A", got)
 	}
-	if got := len(resp.Response.QueryTypeChartData); got != 5 {
-		t.Errorf("len(QueryTypeChartData) = %v, want 5", got)
+	if got := resp.Response.QueryTypeChartData.Datasets[0].Data[0]; got != 100 {
+		t.Errorf("QueryTypeChartData.Datasets[0].Data[0] = %v, want 100", got)
 	}
 
-	// Verify protocolTypeChartData.
-	if got := resp.Response.ProtocolTypeChartData["UDP"]; got != 140 {
-		t.Errorf("ProtocolTypeChartData[UDP] = %v, want 140", got)
+	// Verify protocolTypeChartData (Chart.js format).
+	if got := len(resp.Response.ProtocolTypeChartData.Labels); got != 2 {
+		t.Errorf("len(ProtocolTypeChartData.Labels) = %v, want 2", got)
 	}
-	if got := resp.Response.ProtocolTypeChartData["TCP"]; got != 20 {
-		t.Errorf("ProtocolTypeChartData[TCP] = %v, want 20", got)
+	if got := resp.Response.ProtocolTypeChartData.Datasets[0].Data[0]; got != 140 {
+		t.Errorf("ProtocolTypeChartData.Datasets[0].Data[0] = %v, want 140", got)
 	}
 
 	// Verify topClients.
@@ -347,11 +353,11 @@ func TestStatsResponse_EmptyChartData(t *testing.T) {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}
 
-	if resp.Response.QueryTypeChartData != nil {
-		t.Errorf("QueryTypeChartData = %v, want nil", resp.Response.QueryTypeChartData)
+	if got := len(resp.Response.QueryTypeChartData.Labels); got != 0 {
+		t.Errorf("len(QueryTypeChartData.Labels) = %v, want 0", got)
 	}
-	if resp.Response.ProtocolTypeChartData != nil {
-		t.Errorf("ProtocolTypeChartData = %v, want nil", resp.Response.ProtocolTypeChartData)
+	if got := len(resp.Response.ProtocolTypeChartData.Labels); got != 0 {
+		t.Errorf("len(ProtocolTypeChartData.Labels) = %v, want 0", got)
 	}
 	if resp.Response.TopClients != nil {
 		t.Errorf("TopClients = %v, want nil", resp.Response.TopClients)

--- a/pkg/technitium/client_test.go
+++ b/pkg/technitium/client_test.go
@@ -213,3 +213,158 @@ func TestStatsResponse_JSON(t *testing.T) {
 		t.Errorf("blockListZones = %v, want 50000", resp.Response.Stats.BlockListZones)
 	}
 }
+
+func TestStatsResponse_ChartData(t *testing.T) {
+	jsonData := `{
+		"status": "ok",
+		"response": {
+			"stats": {
+				"totalQueries": 160,
+				"totalNoError": 150,
+				"totalServerFailure": 0,
+				"totalNxDomain": 5,
+				"totalRefused": 5,
+				"totalAuthoritative": 40,
+				"totalRecursive": 100,
+				"totalCached": 15,
+				"totalBlocked": 3,
+				"totalDropped": 2,
+				"totalClients": 5,
+				"zones": 3,
+				"cachedEntries": 200,
+				"allowedZones": 0,
+				"blockedZones": 1,
+				"blockListZones": 50000
+			},
+			"queryTypeChartData": {"A": 100, "AAAA": 40, "TXT": 10, "HTTPS": 5, "PTR": 5},
+			"protocolTypeChartData": {"UDP": 140, "TCP": 20},
+			"topClients": [
+				{"name": "10.0.0.1", "hits": 80, "rateLimited": false},
+				{"name": "10.0.0.2", "hits": 60, "rateLimited": true}
+			],
+			"topDomains": [
+				{"name": "example.com", "hits": 50},
+				{"name": "dns.google", "hits": 30}
+			],
+			"topBlockedDomains": [
+				{"name": "ads.example.com", "hits": 3}
+			]
+		}
+	}`
+
+	var resp StatsResponse
+	if err := json.Unmarshal([]byte(jsonData), &resp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	// Verify queryTypeChartData.
+	if got := resp.Response.QueryTypeChartData["A"]; got != 100 {
+		t.Errorf("QueryTypeChartData[A] = %v, want 100", got)
+	}
+	if got := resp.Response.QueryTypeChartData["AAAA"]; got != 40 {
+		t.Errorf("QueryTypeChartData[AAAA] = %v, want 40", got)
+	}
+	if got := len(resp.Response.QueryTypeChartData); got != 5 {
+		t.Errorf("len(QueryTypeChartData) = %v, want 5", got)
+	}
+
+	// Verify protocolTypeChartData.
+	if got := resp.Response.ProtocolTypeChartData["UDP"]; got != 140 {
+		t.Errorf("ProtocolTypeChartData[UDP] = %v, want 140", got)
+	}
+	if got := resp.Response.ProtocolTypeChartData["TCP"]; got != 20 {
+		t.Errorf("ProtocolTypeChartData[TCP] = %v, want 20", got)
+	}
+
+	// Verify topClients.
+	if got := len(resp.Response.TopClients); got != 2 {
+		t.Fatalf("len(TopClients) = %v, want 2", got)
+	}
+	if got := resp.Response.TopClients[0].Name; got != "10.0.0.1" {
+		t.Errorf("TopClients[0].Name = %v, want 10.0.0.1", got)
+	}
+	if got := resp.Response.TopClients[0].Hits; got != 80 {
+		t.Errorf("TopClients[0].Hits = %v, want 80", got)
+	}
+	if resp.Response.TopClients[0].RateLimited {
+		t.Error("TopClients[0].RateLimited = true, want false")
+	}
+	if !resp.Response.TopClients[1].RateLimited {
+		t.Error("TopClients[1].RateLimited = false, want true")
+	}
+
+	// Verify topDomains.
+	if got := len(resp.Response.TopDomains); got != 2 {
+		t.Fatalf("len(TopDomains) = %v, want 2", got)
+	}
+	if got := resp.Response.TopDomains[0].Name; got != "example.com" {
+		t.Errorf("TopDomains[0].Name = %v, want example.com", got)
+	}
+	if got := resp.Response.TopDomains[0].Hits; got != 50 {
+		t.Errorf("TopDomains[0].Hits = %v, want 50", got)
+	}
+
+	// Verify topBlockedDomains.
+	if got := len(resp.Response.TopBlockedDomains); got != 1 {
+		t.Fatalf("len(TopBlockedDomains) = %v, want 1", got)
+	}
+	if got := resp.Response.TopBlockedDomains[0].Name; got != "ads.example.com" {
+		t.Errorf("TopBlockedDomains[0].Name = %v, want ads.example.com", got)
+	}
+	if got := resp.Response.TopBlockedDomains[0].Hits; got != 3 {
+		t.Errorf("TopBlockedDomains[0].Hits = %v, want 3", got)
+	}
+}
+
+func TestStatsResponse_EmptyChartData(t *testing.T) {
+	// JSON with only stats -- no chart data fields. Verifies backward compatibility.
+	jsonData := `{
+		"status": "ok",
+		"response": {
+			"stats": {
+				"totalQueries": 100,
+				"totalNoError": 90,
+				"totalServerFailure": 2,
+				"totalNxDomain": 5,
+				"totalRefused": 3,
+				"totalAuthoritative": 10,
+				"totalRecursive": 80,
+				"totalCached": 70,
+				"totalBlocked": 5,
+				"totalDropped": 1,
+				"totalClients": 10,
+				"zones": 3,
+				"cachedEntries": 500,
+				"allowedZones": 1,
+				"blockedZones": 2,
+				"blockListZones": 50000
+			}
+		}
+	}`
+
+	var resp StatsResponse
+	if err := json.Unmarshal([]byte(jsonData), &resp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if resp.Response.QueryTypeChartData != nil {
+		t.Errorf("QueryTypeChartData = %v, want nil", resp.Response.QueryTypeChartData)
+	}
+	if resp.Response.ProtocolTypeChartData != nil {
+		t.Errorf("ProtocolTypeChartData = %v, want nil", resp.Response.ProtocolTypeChartData)
+	}
+	if resp.Response.TopClients != nil {
+		t.Errorf("TopClients = %v, want nil", resp.Response.TopClients)
+	}
+	if resp.Response.TopDomains != nil {
+		t.Errorf("TopDomains = %v, want nil", resp.Response.TopDomains)
+	}
+	if resp.Response.TopBlockedDomains != nil {
+		t.Errorf("TopBlockedDomains = %v, want nil", resp.Response.TopBlockedDomains)
+	}
+
+	// Stats should still parse correctly.
+	if resp.Response.Stats.TotalQueries != 100 {
+		t.Errorf("totalQueries = %v, want 100", resp.Response.Stats.TotalQueries)
+	}
+}

--- a/pkg/technitium/types.go
+++ b/pkg/technitium/types.go
@@ -10,12 +10,24 @@ type StatsResponse struct {
 
 // StatsResponseData contains the stats data from the dashboard endpoint.
 type StatsResponseData struct {
-	Stats                 Stats            `json:"stats"`
-	QueryTypeChartData    map[string]int64 `json:"queryTypeChartData"`
-	ProtocolTypeChartData map[string]int64 `json:"protocolTypeChartData"`
-	TopClients            []TopClient      `json:"topClients"`
-	TopDomains            []TopEntry       `json:"topDomains"`
-	TopBlockedDomains     []TopEntry       `json:"topBlockedDomains"`
+	Stats                 Stats       `json:"stats"`
+	QueryTypeChartData    ChartData   `json:"queryTypeChartData"`
+	ProtocolTypeChartData ChartData   `json:"protocolTypeChartData"`
+	TopClients            []TopClient `json:"topClients"`
+	TopDomains            []TopEntry  `json:"topDomains"`
+	TopBlockedDomains     []TopEntry  `json:"topBlockedDomains"`
+}
+
+// ChartData represents Chart.js formatted data from the Technitium dashboard API.
+// The labels slice and datasets[0].Data slice are parallel arrays.
+type ChartData struct {
+	Labels   []string       `json:"labels"`
+	Datasets []ChartDataset `json:"datasets"`
+}
+
+// ChartDataset represents a single dataset in Chart.js formatted data.
+type ChartDataset struct {
+	Data []int64 `json:"data"`
 }
 
 // TopClient represents a top client entry from the dashboard API.

--- a/pkg/technitium/types.go
+++ b/pkg/technitium/types.go
@@ -10,7 +10,25 @@ type StatsResponse struct {
 
 // StatsResponseData contains the stats data from the dashboard endpoint.
 type StatsResponseData struct {
-	Stats Stats `json:"stats"`
+	Stats                 Stats            `json:"stats"`
+	QueryTypeChartData    map[string]int64 `json:"queryTypeChartData"`
+	ProtocolTypeChartData map[string]int64 `json:"protocolTypeChartData"`
+	TopClients            []TopClient      `json:"topClients"`
+	TopDomains            []TopEntry       `json:"topDomains"`
+	TopBlockedDomains     []TopEntry       `json:"topBlockedDomains"`
+}
+
+// TopClient represents a top client entry from the dashboard API.
+type TopClient struct {
+	Name        string `json:"name"`
+	Hits        int64  `json:"hits"`
+	RateLimited bool   `json:"rateLimited"`
+}
+
+// TopEntry represents a top domain entry from the dashboard API.
+type TopEntry struct {
+	Name string `json:"name"`
+	Hits int64  `json:"hits"`
 }
 
 // Stats contains the DNS server statistics.


### PR DESCRIPTION
## Summary

- Add 6 new Prometheus metric families parsed from the existing `/api/dashboard/stats/get` response — no new API calls needed
- Add `--collector.top-entries` CLI flag (default: `true`) to gate top-N metrics containing client IPs and domain names
- Add `technitium_server_uptime_seconds` gauge from the settings endpoint `uptimestamp` field
- Extract `newDesc` helper to keep `NewCollector` under the 100-line funlen limit

## New Metrics

| Metric | Type | Source |
|--------|------|--------|
| `technitium_queries_by_record_type_total` | Counter | `queryTypeChartData` (A, AAAA, TXT, etc.) |
| `technitium_queries_by_protocol_total` | Counter | `protocolTypeChartData` (udp, tcp, etc.) |
| `technitium_top_clients_hits` | Gauge | `topClients` (gated by `--collector.top-entries`) |
| `technitium_top_domains_hits` | Gauge | `topDomains` (gated by `--collector.top-entries`) |
| `technitium_top_blocked_domains_hits` | Gauge | `topBlockedDomains` (gated by `--collector.top-entries`) |
| `technitium_server_uptime_seconds` | Gauge | `settings.uptimestamp` (requires admin token) |

## Changes

- **`pkg/technitium/types.go`** — Expand `StatsResponseData` with 5 new fields; add `TopClient` and `TopEntry` types
- **`collector/collector.go`** — Add 6 descriptors, `topEntriesEnabled` flag, `collectChartData`/`collectUptime` helpers
- **`cmd/technitium_exporter/main.go`** — Add `--collector.top-entries` kingpin flag
- **`collector/collector_test.go`** — Update fixtures with chart data; add 8 new test functions (21 total)
- **`pkg/technitium/client_test.go`** — Add `TestStatsResponse_ChartData` and `TestStatsResponse_EmptyChartData`
- **`CLAUDE.md`** — Update metrics table with 6 new entries
- **`docs/exporter-enhancements-implementation.md`** — Phased implementation plan with checked-off criteria

## Test plan

- [x] `make fmt` — no changes
- [x] `make lint` — 0 issues
- [x] `make test` — 27 tests pass (21 collector + 6 client), race detector enabled
- [x] `make test-coverage` — collector: 97.8%, client: 91.5%
- [x] `make build` — binary builds successfully
- [x] `make security` — govulncheck clean, trivy 0 findings
- [x] Manual smoke test against running Technitium server

🤖 Generated with [Claude Code](https://claude.com/claude-code)